### PR TITLE
Fix unexpected auto line-break

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,7 @@ jobs:
       # documented at https://circleci.com/docs/2.0/circleci-images/
       # - image: circleci/postgres:9.4
 
-    #### TEMPLATE_NOTE: go expects specific checkout path representing
-url
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
     #### expecting it in the form of
     ####   /go/src/github.com/circleci/go-tool
     ####   /go/src/bitbucket.org/circleci/go-tool


### PR DESCRIPTION
Fix unexpected auto line-break

```
    #### TEMPLATE_NOTE: go expects specific checkout path representing
url
    #### expecting it in the form of
```
to
```
    #### TEMPLATE_NOTE: go expects specific checkout path representing url
    #### expecting it in the form of
```