### PR TITLE
Update Go version from 1.9 to 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.12
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
Update Go version from 1.9 to 1.12

```
      # specify the version
      - image: circleci/golang:1.9
```
to
```
      # specify the version
      - image: circleci/golang:1.12
```